### PR TITLE
Feature/fms gnu10

### DIFF
--- a/buildscripts/libs/build_fms.sh
+++ b/buildscripts/libs/build_fms.sh
@@ -35,9 +35,11 @@ else
 fi
 
 export FC=$MPI_FC
+[[ -n $FC && `$FC --version` =~ GNU\ Fortran.*\ 1[0-9]\.[0-9]+ ]] && FC_GFORTRAN_10=1
 export CC=$MPI_CC
 
 export FFLAGS+=" -fPIC -w"
+[[ -n $FC_GFORTRAN_10 ]] && export FFLAGS+=" -fallow-argument-mismatch"
 export CFLAGS+=" -fPIC -w"
 export FCFLAGS="$FFLAGS"
 


### PR DESCRIPTION
## Description

Already approved on JCSDA-public so I am merging

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #<issue_number>

## Dependencies

If there are PRs that need to be merged before or along with this one, please add "waiting for another PR" label and list the dependencies in the other repositories (example below). Note that the branches in the other repositories should have matching names for the automated tests to pass.
Waiting on the following PRs:
- waiting on JCSDA/eckit/pull/<pr_number>
- waiting on JCSDA/atlas/pull/<pr_number>

## Impact

If changes in this PR will affect other repositories, please add a "waiting for other repos" label, and list the repositories that will be affected to the best of your knowledge (example below).
Requires changes in the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ufo
- [ ] ...

If changes in this PR require updating test data on AWS please add an "update test data" label and list the test data that needs to be updated to the best of your knowledge (example below).
Requires updating AWS test data for the following repositories:
- [ ] saber
- [ ] ioda
- [ ] ...

Note: to automatically run saber, ioda and ufo tests with this PR, push a commit containing "trigger pipeline", e.g.:
git commit --allow-empty -m 'trigger pipeline'
