### PR TITLE
Update json-schema-validator to successfully build

### DIFF
--- a/buildscripts/config/config_container-clang-mpich-dev.sh
+++ b/buildscripts/config/config_container-clang-mpich-dev.sh
@@ -80,6 +80,6 @@ export          STACK_BUILD_CGAL=N
 export          STACK_BUILD_GEOS=N
 export        STACK_BUILD_SQLITE=N
 export          STACK_BUILD_PROJ=N
-export          STACK_BUILD_JSON=N
+export          STACK_BUILD_JSON=Y
 export STACK_BUILD_JSON_SCHEMA_VALIDATOR=Y
 export           STACK_BUILD_FMS=N

--- a/buildscripts/config/config_container-gnu-openmpi-dev.sh
+++ b/buildscripts/config/config_container-gnu-openmpi-dev.sh
@@ -81,6 +81,6 @@ export          STACK_BUILD_CGAL=N
 export          STACK_BUILD_GEOS=N
 export        STACK_BUILD_SQLITE=N
 export          STACK_BUILD_PROJ=N
-export          STACK_BUILD_JSON=N
+export          STACK_BUILD_JSON=Y
 export STACK_BUILD_JSON_SCHEMA_VALIDATOR=Y
 export           STACK_BUILD_FMS=N

--- a/buildscripts/config/config_container-intel-impi-dev.sh
+++ b/buildscripts/config/config_container-intel-impi-dev.sh
@@ -82,6 +82,6 @@ export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
 export          STACK_BUILD_CGAL=N
-export          STACK_BUILD_JSON=N
+export          STACK_BUILD_JSON=Y
 export STACK_BUILD_JSON_SCHEMA_VALIDATOR=Y
 export           STACK_BUILD_FMS=N

--- a/buildscripts/libs/build_json-schema-validator.sh
+++ b/buildscripts/libs/build_json-schema-validator.sh
@@ -12,8 +12,8 @@ if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
     module load jedi-$JEDI_COMPILER
-    module try-load cmake
-    module try-load json
+    module load cmake
+    module load json
     module list
     set -x
 
@@ -38,12 +38,14 @@ url="https://github.com/pboettch/json-schema-validator/archive/$tarfile"
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
-echo nlohmann_json_DIR=$nlohmann_json_DIR
+[[ -n $nlohmann_json_ROOT ]] || ( echo "Required json.hpp class not installed, ABORT!"; exit 1 )
+echo nlohmann_json_DIR=$nlohmann_json_ROOT
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_POLICY_DEFAULT_CMP0074=NEW \
       -DBUILD_SHARED_LIBS=Y \
+      -Dnlohmann_json_DIR=$nlohmann_json_ROOT/include \
       -DBUILD_TESTS=$MAKE_CHECK \
       -DBUILD_EXAMPLES=N
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test

--- a/buildscripts/libs/build_json-schema-validator.sh
+++ b/buildscripts/libs/build_json-schema-validator.sh
@@ -12,7 +12,7 @@ if $MODULES; then
     set +x
     source $MODULESHOME/init/bash
     module load jedi-$JEDI_COMPILER
-    module load cmake
+    module try-load cmake
     module load json
     module list
     set -x
@@ -38,14 +38,14 @@ url="https://github.com/pboettch/json-schema-validator/archive/$tarfile"
 [[ -d build ]] && rm -rf build
 mkdir -p build && cd build
 
-[[ -n $nlohmann_json_ROOT ]] || ( echo "Required json.hpp class not installed, ABORT!"; exit 1 )
-echo nlohmann_json_DIR=$nlohmann_json_ROOT
+[[ -n $JSON_DIR ]] || ( echo "Required json cmake configuration not found, ABORT!"; exit 1 )
+
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_BUILD_TYPE=Release \
       -DCMAKE_POLICY_DEFAULT_CMP0074=NEW \
       -DBUILD_SHARED_LIBS=Y \
-      -Dnlohmann_json_DIR=$nlohmann_json_ROOT/include \
+      -Dnlohmann_json_DIR=$JSON_DIR \
       -DBUILD_TESTS=$MAKE_CHECK \
       -DBUILD_EXAMPLES=N
 [[ $MAKE_CHECK =~ [yYtT] ]] && make test

--- a/buildscripts/libs/build_json-schema-validator.sh
+++ b/buildscripts/libs/build_json-schema-validator.sh
@@ -24,7 +24,8 @@ if $MODULES; then
     fi
 
 else
-    prefix=${json_ROOT:-"/usr/local"}
+    prefix=${JSON_ROOT:-"/usr/local"}
+    JSON_DIR=${JSON_DIR:-$prefix/lib/cmake/nlohmann_json}
 fi
 
 cd $JEDI_STACK_ROOT/${PKGDIR:-"pkg"}
@@ -39,7 +40,6 @@ url="https://github.com/pboettch/json-schema-validator/archive/$tarfile"
 mkdir -p build && cd build
 
 [[ -n $JSON_DIR ]] || ( echo "Required json cmake configuration not found, ABORT!"; exit 1 )
-
 cmake .. \
       -DCMAKE_INSTALL_PREFIX=$prefix \
       -DCMAKE_BUILD_TYPE=Release \

--- a/buildscripts/libs/build_netcdf.sh
+++ b/buildscripts/libs/build_netcdf.sh
@@ -120,8 +120,6 @@ echo "##########################################################################
 # Load netcdf-c before building netcdf-fortran
 $MODULES && module load netcdf
 
-module list
-
 set -x
 
 cd $curr_dir

--- a/modulefiles/core/json/json.lua
+++ b/modulefiles/core/json/json.lua
@@ -11,7 +11,8 @@ local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
 
 local base = pathJoin(opt,"core",pkgName,pkgVersion)
 
-setenv("nlohmann_json_ROOT", base)
+setenv("JSON_ROOT", base)
+setenv("JSON_DIR", pathJoin(base,"lib","cmake","nlohmann_json"))
 
 whatis("Name: ".. pkgName)
 whatis("Version: " .. pkgVersion)


### PR DESCRIPTION
## Description

Update component `json-schema-validator` build script to properly configure cmake and successfully build the component.

The build script for jedi-stack component `json-schema-validator` depends on successful installation of the JSON for C++ stack component. The schema validator must know the location of the single header file `json.hpp`, which is set in JSON stack module description file. The variable  that defines this root directory location is used by the script to configure and build the schema validator.

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #35
- fixes #37 

## Dependencies

No dependencies

## Impact

The `lua` module file for the `json` stack component is modified to set two variables:

- `JSON_ROOT`: location of the json.hpp file used in JEDI code
- `JSON_DIR`: location of json stack component cmake files used to configure and build the schema validator
