### PR TITLE
add mpfr to stack (CGAL dependency)

### DIFF
--- a/buildscripts/build_stack.sh
+++ b/buildscripts/build_stack.sh
@@ -88,6 +88,7 @@ build_lib BOOST_HDRS boost 1.68.0 headers-only
 build_lib EIGEN3 eigen 3.3.7
 build_lib BUFRLIB bufrlib 11.3.2
 build_lib ECBUILD ecbuild jcsda 3.3.2.jcsda3
+build_lib MPFR mpfr 4.1.0
 build_lib CGAL cgal 5.0.2
 build_lib GITLFS git-lfs 2.11.0
 

--- a/buildscripts/config/choose_modules.sh
+++ b/buildscripts/config/choose_modules.sh
@@ -42,6 +42,7 @@ export          STACK_BUILD_ESMF=N
 export      STACK_BUILD_BASELIBS=N
 export     STACK_BUILD_PDTOOLKIT=N
 export          STACK_BUILD_TAU2=N
+export          STACK_BUILD_MPFR=N
 export          STACK_BUILD_CGAL=N
 export          STACK_BUILD_GEOS=N
 export        STACK_BUILD_SQLITE=N

--- a/buildscripts/libs/build_cgal.sh
+++ b/buildscripts/libs/build_cgal.sh
@@ -33,6 +33,7 @@ if $MODULES; then
     module try-load cmake
     module try-load boost-headers
     module try-load zlib
+    module try-load mpfr
     module list
     set -x
 

--- a/buildscripts/libs/build_mpfr.sh
+++ b/buildscripts/libs/build_mpfr.sh
@@ -1,0 +1,59 @@
+#!/bin/bash
+# © Copyright 2020 UCAR
+# This software is licensed under the terms of the Apache Licence Version 2.0 which can be obtained at
+# http://www.apache.org/licenses/LICENSE-2.0.
+
+set -ex
+
+name="mpfr"
+version=$1
+
+# Hyphenated version used for install prefix
+compiler=$(echo $JEDI_COMPILER | sed 's/\//-/g')
+
+# manage package dependencies here
+if $MODULES; then
+    set +x
+    source $MODULESHOME/init/bash
+    module load jedi-$JEDI_COMPILER
+    module list
+    set -x
+
+    prefix="${PREFIX:-"/opt/modules"}/$compiler/$name/$version"
+    if [[ -d $prefix ]]; then
+        [[ $OVERWRITE =~ [yYtT] ]] && ( echo "WARNING: $prefix EXISTS: OVERWRITING!";$SUDO rm -rf $prefix ) \
+                                   || ( echo "WARNING: $prefix EXISTS, SKIPPING"; exit 1 )
+    fi
+
+else
+    prefix=${MPFR_ROOT:-"/usr/local"}
+fi
+
+export CC=$SERIAL_CC
+export CXX=$SERIAL_CXX
+export FC=$SERIAL_FC
+
+export FFLAGS+=" -fPIC"
+export CFLAGS+=" -fPIC"
+export CXXFLAGS+=" -fPIC"
+export FCFLAGS="$FFLAGS"
+
+cd ${JEDI_STACK_ROOT}/${PKGDIR:-"pkg"}
+
+software=$name-$version
+url=https://www.mpfr.org/mpfr-current/$software.tar.gz
+[[ -d $software ]] || ( $WGET $url; tar -xf $software.tar.gz )
+[[ ${DOWNLOAD_ONLY} =~ [yYtT] ]] && exit 0
+[[ -d $software ]] && cd $software || ( echo "$software does not exist, ABORT!"; exit 1 )
+[[ -d build ]] && rm -rf build
+mkdir -p build && cd build
+
+../configure --prefix=$prefix
+
+make V=$MAKE_VERBOSE -j${NTHREADS:-4}
+[[ $MAKE_CHECK =~ [yYtT] ]] && make check
+$SUDO make install
+
+# generate modulefile from template
+$MODULES && update_modules compiler $name $version \
+         || echo $name $version >> ${JEDI_STACK_ROOT}/jedi-stack-contents.log

--- a/modulefiles/compiler/compilerName/compilerVersion/mpfr/mpfr.lua
+++ b/modulefiles/compiler/compilerName/compilerVersion/mpfr/mpfr.lua
@@ -1,0 +1,30 @@
+help([[
+]])
+
+local pkgName    = myModuleName()
+local pkgVersion = myModuleVersion()
+local pkgNameVer = myModuleFullName()
+
+local hierA        = hierarchyA(pkgNameVer,1)
+local compNameVer  = hierA[1]
+local compNameVerD = compNameVer:gsub("/","-")
+
+conflict(pkgName)
+
+local opt = os.getenv("JEDI_OPT") or os.getenv("OPT") or "/opt/modules"
+
+local base = pathJoin(opt,compNameVerD,pkgName,pkgVersion)
+
+prepend_path("LD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("DYLD_LIBRARY_PATH", pathJoin(base,"lib"))
+prepend_path("CPATH", pathJoin(base,"include"))
+
+setenv("MPFR_ROOT", base)
+setenv("MPFR_INCLUDES", pathJoin(base,"include"))
+setenv("MPFR_LIBRARIES", pathJoin(base,"lib"))
+setenv("MPFR_VERSION", pkgVersion)
+
+whatis("Name: ".. pkgName)
+whatis("Version: " .. pkgVersion)
+whatis("Category: library")
+whatis("Description: MPFR library")


### PR DESCRIPTION
## Description

This adds a build script for [the GNU MPFR library](https://www.mpfr.org/).

MPFR is a dependency for CGAL.

for containers and laptops MPFR can easily be installed by homebrew/pat/yum but for HPC systems we need to install it from source.  This was used to install it on Cheyenne for gnu-openmpi

### Issue(s) addressed

Link the issues to be closed with this PR
- fixes #https://github.com/JCSDA-internal/mpas-jedi/issues/437

## Dependencies



## Impact

